### PR TITLE
Fix missing `function.jq` due to packaging flaw

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed missing `function.jq` due to packaging flaw
 
 ## 2025/03/17 v0.2.1
 - Chore: Remove silly log statement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,9 @@ urls.Repository = "https://github.com/panodata/tikray"
 
 scripts.tikray = "tikray.cli:cli"
 
+[tool.setuptools.package-data]
+tikray = ["*.jq"]
+
 [tool.black]
 line-length = 120
 


### PR DESCRIPTION
What the title says.